### PR TITLE
chore: bump jruby from 9.3.6.0 to 9.4.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,7 @@
       <dependency>
         <groupId>org.jruby</groupId>
         <artifactId>jruby</artifactId>
-        <version>9.3.6.0</version>
+        <version>9.4.2.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Bumps jruby from 9.3.6.0 to 9.4.2.0.

---
updated-dependencies:
- dependency-name: org.jruby:jruby dependency-type: direct:production update-type: version-update:semver-minor ...

Thank you for submitting a pull request to the WebGoat!
